### PR TITLE
HCU #103 - Fehlende englische Übersetzung.

### DIFF
--- a/module/Libraries/src/Libraries/AjaxHandler/GetLibraries.php
+++ b/module/Libraries/src/Libraries/AjaxHandler/GetLibraries.php
@@ -33,6 +33,7 @@ use VuFind\Search\Memory;
 use Libraries\Libraries;
 use VuFind\AjaxHandler\AbstractBase;
 use Zend\Mvc\Controller\Plugin\Params;
+use Zend\Mvc\I18n\Translator;
 use Zend\Stdlib\Parameters;
 use Zend\Config\Config;
 
@@ -62,17 +63,25 @@ class GetLibraries extends AbstractBase
     protected $resultsManager;
 
     /**
+     * Translation helper
+     *
+     * @var TransEsc
+     */
+    protected $translator;
+
+    /**
      * Constructor
      *
      * @param ServiceLocatorInterface $sm Service locator
      */
-    public function __construct(Config $config, ResultsManager $resultsManager, Memory $searchMemory)
+    public function __construct(Config $config, ResultsManager $resultsManager, Memory $searchMemory, Translator $translator)
     {
         $this->resultsManager = $resultsManager;
         $this->Libraries = new Libraries(
             $config,
             $searchMemory
         );
+        $this->translator = $translator;
     }
 
     /**
@@ -156,7 +165,7 @@ class GetLibraries extends AbstractBase
                     }
                 }
             }
-            $libraryData[$libraryCode] = ['fullname' => $library['fullname'], 'count' => $count];
+            $libraryData[$libraryCode] = ['fullname' => $this->translator->translate($library['fullname']), 'count' => $count];
         }
 
 //print_r($libraryData);

--- a/module/Libraries/src/Libraries/AjaxHandler/GetLibrariesFactory.php
+++ b/module/Libraries/src/Libraries/AjaxHandler/GetLibrariesFactory.php
@@ -68,7 +68,8 @@ class GetLibrariesFactory
         return new $requestedName(
             $container->get('VuFind\Config\PluginManager')->get('libraries'),
             $container->get('Libraries\Search\Results\PluginManager'),
-            $container->get('VuFind\Search\Memory')
+            $container->get('VuFind\Search\Memory'),
+            $container->get('VuFind\Translator')
         );
     }
 }


### PR DESCRIPTION
Übersetzung der Fullname-Angaben aus der libraries.ini beim AJAX-Abruf des Bibliotheksselektors:

http://.../vufind/AJAX/JSON?method=getLibraries&...

- Translator über GetLibrariesFactory dem AjaxHandler GetLibraries hinzugefügt.