### PR TITLE
Develop 5 recorddriver Erweiterungen

### DIFF
--- a/module/RecordDriver/src/RecordDriver/RecordDriver/SolrMarc.php
+++ b/module/RecordDriver/src/RecordDriver/RecordDriver/SolrMarc.php
@@ -328,10 +328,19 @@ class SolrMarc extends SolrDefault
                                             $subFieldList[$subField]['filter'] = $spec[1];
                                             $subFieldList[$subField]['match'] = intval($spec[2]);
                                         } elseif ($spec[0] == 'replace') {
-                                            $subFieldList[$subField]['toReplace'] = $spec[1];
-                                            $subFieldList[$subField]['replacement'] = $spec[2];
+                                            if (!isset($subFieldList[$subField]['toReplace'])) {
+                                                $subFieldList[$subField]['toReplace'] = [];
+                                                $subFieldList[$subField]['replacement'] = [];
+                                            }
+                                            $subFieldList[$subField]['toReplace'][] = $spec[1];
+                                            $subFieldList[$subField]['replacement'][] = $spec[2];
                                         } elseif ($spec[0] == 'function') {
-                                            $subFieldList[$subField]['function'] = $spec[1];
+                                            if (!isset($subFieldList[$subField]['function'])) {
+                                                $subFieldList[$subField]['function'] = [];
+                                                $subFieldList[$subField]['parameter'] = [];
+                                            }
+                                            $subFieldList[$subField]['function'][] = $spec[1];
+                                            $subFieldList[$subField]['parameter'][] = $spec[2];
                                         }
                                     }
                                 }
@@ -359,12 +368,21 @@ class SolrMarc extends SolrDefault
                                             $fieldDate = '';
                                         }
                                     }
-                                    if (isset($properties['toReplace']) && isset($properties['replacement'])) {
-                                        $fieldDate = preg_replace('/' . $properties['toReplace'] . '/', $properties['replacement'], $fieldDate);
-                                    }
                                     if (isset($properties['function'])) {
-                                        $function = $properties['function'];
-                                        $fieldDate = $function($fieldDate);
+                                        for ($i = 0; $i < count($properties['function']); $i++) {
+                                            $function = $properties['function'][$i];
+                                            if (!empty($properties['parameter'][$i])) {
+                                                $fieldDate = $function($fieldDate, $properties['parameter'][$i]);
+                                                #$fieldDate = $function($fieldDate, MB_CASE_TITLE);
+                                            } else {
+                                                $fieldDate = $function($fieldDate);
+                                            }
+                                        }
+                                    }
+                                    if (isset($properties['toReplace']) && isset($properties['replacement'])) {
+                                        for ($i = 0; $i < count($properties['toReplace']); $i++) {
+                                            $fieldDate = preg_replace('/' . $properties['toReplace'][$i] . '/', $properties['replacement'][$i], $fieldDate);
+                                        }
                                     }
                                     $fieldDate = trim($fieldDate);
                                     if (empty($fieldDate) && $fieldDate !== '0' && $fieldDate !== 0) {

--- a/themes/recorddriver/templates/RecordDriver/SolrDefault/link-issnj.phtml
+++ b/themes/recorddriver/templates/RecordDriver/SolrDefault/link-issnj.phtml
@@ -1,0 +1,3 @@
+<?php $searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction(); ?>
+<?php $searchRoute = 'search-results'; ?>
+<?=$this->url($searchRoute)?>?lookfor=%22<?=urlencode($this->lookfor)?>%22&type=ISN&filter[]=format_phy_str_mv:Journal

--- a/themes/recorddriver/templates/RecordDriver/SolrDefault/recorddriver-result-list.phtml
+++ b/themes/recorddriver/templates/RecordDriver/SolrDefault/recorddriver-result-list.phtml
@@ -32,7 +32,7 @@
           <?=strtolower($this->transEsc($resultList['relation']))?>:
         <?php endif; ?>
         <?php if(!empty($resultList['journallink'])): ?>
-          <a href="<?=$this->record($this->driver)->getLink('isn', $resultList['journallink'])?>">
+          <a href="<?=$this->record($this->driver)->getLink('issnj', $resultList['journallink'])?>">
             <?=$resultList['journal'] ?>
           </a>
         <?php else: ?>


### PR DESCRIPTION
zwei Erweiterungen: 
Zum einen werden jetzt pro Marcfeld auch mehrere replace- und function-Optionen hintereinander angewendet - falls konfiguriert. Vorher wurde jeweils nur die erste Option ausgewertet.

Es gibt ein zusätzliches Linktemplate für Journals, in dem ein isn-Link zusätzlich auf das Medium journal eingegrenzt wird. Auf diese Weise wird bei der Suche nur die Hauptaufnahme gefunden, nicht auch noch sämtliche Bände. Dieses neue Linktemplate wird als Standard für die Journal-Links in der Listenansicht gesetzt.