### PR TITLE
Der Handler gab in value und label den Wert von value zurück, also z.…

### DIFF
--- a/module/SearchKeys/src/SearchKeys/View/Helper/SearchKeys/SearchBox.php
+++ b/module/SearchKeys/src/SearchKeys/View/Helper/SearchKeys/SearchBox.php
@@ -50,7 +50,7 @@ class SearchBox extends \VuFind\View\Helper\Root\SearchBox
         $searchKeys = array_unique($searchKeys);
         foreach( $searchKeys as $key => $value) {
             $handlers[] = [
-                'value' => $value, 'label' => $value, 'indent' => false, 'selected' => ($activeHandler == $value)
+                'value' => $value, 'label' => $key, 'indent' => false, 'selected' => ($activeHandler == $value)
             ];
         }
         return $handlers;

--- a/themes/belugax/templates/search/searchbox.phtml
+++ b/themes/belugax/templates/search/searchbox.phtml
@@ -111,6 +111,14 @@
             $this->lookfor = '';
         }
     } else {
+		if($this->searchType == 'basic') {
+			if($this->searchIndex != "AllFields") {
+				$this->lookfor = $this->searchIndex.':'.$this->lookfor;
+			} else {
+				$this->lookfor = $this->lookfor;
+			}				
+		}
+		
         if (is_array($keywords)) {
             foreach ($keywords as $identifier => $type) {
                 $this->lookfor = str_replace($type . ":", $identifier . " ", $this->lookfor);

--- a/themes/belugax/templates/search/searchbox.phtml
+++ b/themes/belugax/templates/search/searchbox.phtml
@@ -11,10 +11,10 @@
         isset($this->searchIndex) ? $this->searchIndex : null
     );
 
-	$keywords = array();
-	foreach($handlers as $handler){
-		$keywords[$handler['label']] = $handler['value'];
-	}
+    $keywords = array();
+    foreach($handlers as $handler){
+        $keywords[$handler['label']] = $handler['value'];
+    }
 
     $handlerCount = count($handlers);
     $basicSearch = $this->searchbox()->combinedHandlersActive() ? 'combined-searchbox' : $options->getSearchAction();
@@ -38,7 +38,7 @@
     $searchIndex = $this->searchIndex;
     $searchType = $this->searchType;
 
-    if ($this->lookfor == '') {
+    if (empty($this->lookfor)) {
         if ($_GET['lookfor'])  {
             $this->lookfor = $_GET['lookfor'];
             foreach($keywords as $identifier => $type) {

--- a/themes/belugax/templates/search/searchbox.phtml
+++ b/themes/belugax/templates/search/searchbox.phtml
@@ -10,6 +10,12 @@
         $this->searchClassId,
         isset($this->searchIndex) ? $this->searchIndex : null
     );
+
+	$keywords = array();
+	foreach($handlers as $handler){
+		$keywords[$handler['label']] = $handler['value'];
+	}
+
     $handlerCount = count($handlers);
     $basicSearch = $this->searchbox()->combinedHandlersActive() ? 'combined-searchbox' : $options->getSearchAction();
     $searchHome = $options->getSearchHomeAction();


### PR DESCRIPTION
…B. bei Konfiguration

TIT = Title
erhielt man
value = Title
und
label = Title
damit war ist in der searchbox.phtml keine Übersetzung der Suchtypen in Suchschlüssel möglich gewesen.