### PR TITLE
Configuration of filter/searchfield and Bugfix visibile/non-visible elements

### DIFF
--- a/config/vufind/dependent-works.ini
+++ b/config/vufind/dependent-works.ini
@@ -2,3 +2,4 @@
 
 limit =500 
 sort = SORT_REGULAR
+;searchfield = hierarchy_top_id ;field to search for records connected to an id, default is hierarchy_top_id

--- a/config/vufind/dependent-works.ini
+++ b/config/vufind/dependent-works.ini
@@ -3,3 +3,4 @@
 limit =500 
 sort = SORT_REGULAR
 ;searchfield = hierarchy_top_id ;field to search for records connected to an id, default is hierarchy_top_id
+;filter = '-format:Article' ;a filter can be added, default no filter

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -92,7 +92,7 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
             false : ($this->config['Global']['switch_to_regular_search'] == 'y');
         $searchfield = empty($this->config['Global']['searchfield']) ?
             'hierarchy_top_id' : $this->config['Global']['searchfield'];
-        $filter = !empty($this->config['Global']['filter']) ?
+        $filter = empty($this->config['Global']['filter']) ?
             '' : $this->config['Global']['filter'];
 
         $ppn = $params->fromQuery('ppn');

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -87,18 +87,13 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
     {
         $limit = $this->config['Global']['limit'] ?? 1;
         $sortFlag = $this->config['Global']['sort'] ?? SORT_REGULAR;
-        $switchToRegularSearch = ($this->config['Global']['switch_to_regular_search'] == 'y');
-		if(isset($this->config['Global']['searchfield']) && !empty($this->config['Global']['searchfield'])){
-		    $searchfield = $this->config['Global']['searchfield'];
-		} else {
-		    $searchfield = 'hierarchy_top_id';
-		}
-		
-		if(isset($this->config['Global']['filter']) && !empty($this->config['Global']['filter'])){
-		    $filter = $this->config['Global']['filter'];
-		} else {
-		    $filter = '';
-		}
+
+        $switchToRegularSearch = empty($this->config['Global']['switch_to_regular_search']) ?
+            false : ($this->config['Global']['switch_to_regular_search'] == 'y');
+        $searchfield = empty($this->config['Global']['searchfield']) ?
+            'hierarchy_top_id' : $this->config['Global']['searchfield'];
+        $filter = !empty($this->config['Global']['filter']) ?
+            '' : $this->config['Global']['filter'];
 
         $ppn = $params->fromQuery('ppn');
         if (empty($ppn)) {
@@ -122,7 +117,7 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
         foreach ($records as $i => $record) {
             $dependentWorksData = $record->getMarcData('DependentWorksData');
             $title = $part = $date = $sort = '';
-            $sort = $i; // Keep this default setting outside inner foreach loop, otherwise $sort gets reset to $i even if value of $dependentWorksDate['sort']['data'][0] was previously set.
+            $sort = $i;
             foreach ($dependentWorksData as $dependentWorksDate) {
                 if (empty($title) && !empty($dependentWorksDate['title']['data'][0])) {
                     $title = $dependentWorksDate['title']['data'][0];

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -88,6 +88,11 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
         $limit = $this->config['Global']['limit'] ?? 1;
         $sortFlag = $this->config['Global']['sort'] ?? SORT_REGULAR;
         $switchToRegularSearch = ($this->config['Global']['switch_to_regular_search'] == 'y');
+		if(isset($this->config['Global']['searchfield']) && !empty($this->config['Global']['searchfield'])){
+		    $searchfield = $this->config['Global']['searchfield'];
+		} else {
+		    $searchfield = 'hierarchy_top_id';
+		}
 
         $ppn = $params->fromQuery('ppn');
         if (empty($ppn)) {
@@ -97,14 +102,14 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
         $results = $this->resultsManager->get($backend);
         $results->getOptions()->setLimitOptions([$limit, $limit]);
         $paramsObj = $results->getParams();
-        $paramsObj->initFromRequest(new Parameters(['lookfor' => 'hierarchy_top_id:'.$ppn.' -id:'.$ppn]));
+        $paramsObj->initFromRequest(new Parameters(['lookfor' => $searchfield.':'.$ppn.' -id:'.$ppn]));
 
         $records = $results->getResults();
         $resultTotal = $results->getResultTotal();
 
         if ($switchToRegularSearch && $resultTotal > $limit) {
             $resultString = $resultTotal . ' ' . $this->translate('results') . ': ' . $this->translate('show all');
-            return $this->formatResponse([['resultString' => (string) $resultString]]);
+            return $this->formatResponse([['resultString' => (string) $resultString, 'searchfield' => $searchfield]]);
         }
 
         $data = [];

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -137,9 +137,6 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
                     $sort = $dependentWorksDate['sort']['data'][0];
                 }
             }
-            if (empty($sort)) {
-                $sort = $i;
-            }
             $prefix = (empty($date)) ? $part . '. ' : $part . ', ' . $date . '. ';
             $data[$sort] = ['id' => $record->getUniqueID(),
                             'prefix' => $prefix,

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -93,6 +93,12 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
 		} else {
 		    $searchfield = 'hierarchy_top_id';
 		}
+		
+		if(isset($this->config['Global']['filter']) && !empty($this->config['Global']['filter'])){
+		    $filter = $this->config['Global']['filter'];
+		} else {
+		    $filter = '';
+		}
 
         $ppn = $params->fromQuery('ppn');
         if (empty($ppn)) {
@@ -102,14 +108,14 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
         $results = $this->resultsManager->get($backend);
         $results->getOptions()->setLimitOptions([$limit, $limit]);
         $paramsObj = $results->getParams();
-        $paramsObj->initFromRequest(new Parameters(['lookfor' => $searchfield.':'.$ppn.' -id:'.$ppn]));
+        $paramsObj->initFromRequest(new Parameters(['lookfor' => $searchfield.':'.$ppn.' -id:'.$ppn, 'filter' => $filter]));
 
         $records = $results->getResults();
         $resultTotal = $results->getResultTotal();
 
         if ($switchToRegularSearch && $resultTotal > $limit) {
             $resultString = $resultTotal . ' ' . $this->translate('results') . ': ' . $this->translate('show all');
-            return $this->formatResponse([['resultString' => (string) $resultString, 'searchfield' => $searchfield]]);
+            return $this->formatResponse([['resultString' => (string) $resultString, 'searchfield' => $searchfield, 'filter' => $filter]]);
         }
 
         $data = [];

--- a/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
+++ b/module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php
@@ -104,7 +104,7 @@ class GetDependentWorks extends AbstractBase implements TranslatorAwareInterface
         if (empty($ppn)) {
             return $this->formatResponse([]);
         }
-        $backend = $params->fromQuery('source', DEFAULT_SEARCH_BACKEND);
+        $backend = $params->fromQuery('source');
         $results = $this->resultsManager->get($backend);
         $results->getOptions()->setLimitOptions([$limit, $limit]);
         $paramsObj = $results->getParams();

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -30,8 +30,11 @@ jQuery(document).ready(function() {
             if (data.data.length > 0) {
                 if (data.data[0]['resultString'] !== undefined) {
                     var href = '<a href="/vufind/'+ResultPath+'/Results?lookfor='+data.data[0]['searchfield']+':'
-                            + recordId + ' -id:'  + recordId + '&filter[]='+data.data[0]['filter']+'&sort=year">'
-                            + data.data[0]['resultString'] + '</a>'
+                            + recordId + ' -id:'  + recordId;
+                    if (data.data[0]['filter'].length > 0) {
+                        href += '&filter[]='+data.data[0]['filter'];
+                    }
+                    href += '&sort=year">' + data.data[0]['resultString'] + '</a>';
                     jQuery('ul#DependentWorks').append('<li>' + href + '</li>');
                 } else {
                     var visibleItems = (data.data.length < 3) ? data.data.length : 3;

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -20,7 +20,7 @@ jQuery(document).ready(function() {
         success:function(data, textStatus) {
             if (data.data.length > 0) {
                 if (data.data[0]['resultString'] !== undefined) {
-                    var href = '<a href="/vufind/Search/Results?lookfor=hierarchy_top_id:'
+                    var href = '<a href="/vufind/Search/Results?lookfor='+data.data[0]['searchfield']+':'
                             + recordId + ' -id:'  + recordId + '&sort=year">'
                             + data.data[0]['resultString'] + '</a>'
                     jQuery('ul#DependentWorks').append('<li>' + href + '</li>');

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -1,5 +1,7 @@
 jQuery(document).ready(function() {
     var recordId;
+    var SearchClassId = 'Solr';
+    var RecordPath = 'Record';
     var pathParts = window.location.href.split('/');
     var recordIndex = pathParts.length - 1;
     if (pathParts[recordIndex] == 'Record' || pathParts[recordIndex] == 'Search2Record') {
@@ -12,15 +14,20 @@ jQuery(document).ready(function() {
         recordId = 0;
       }
     }
+    
+    if (pathParts[recordIndex] == 'Search2Record') {
+      var SearchClassId = 'Search2';
+      var RecordPath = 'Search2Record';
+    }
 
     jQuery.ajax({
         url:'/vufind/AJAX/JSON?method=getDependentWorks',
         dataType:'json',
-        data:{ppn:recordId},
+        data:{ppn:recordId, source:SearchClassId},
         success:function(data, textStatus) {
             if (data.data.length > 0) {
                 if (data.data[0]['resultString'] !== undefined) {
-                    var href = '<a href="/vufind/Search/Results?lookfor='+data.data[0]['searchfield']+':'
+                    var href = '<a href="/vufind/'+SearchClassId+'/Results?lookfor='+data.data[0]['searchfield']+':'
                             + recordId + ' -id:'  + recordId + '&filter[]='+data.data[0]['filter']+'&sort=year">'
                             + data.data[0]['resultString'] + '</a>'
                     jQuery('ul#DependentWorks').append('<li>' + href + '</li>');
@@ -28,7 +35,7 @@ jQuery(document).ready(function() {
                     var visibleItems = (data.data.length < 3) ? data.data.length : 3;
                     for (var i = 0; i < visibleItems; i++) {
                         var title = data.data[i]['title'];
-                        var href = '<a href="/vufind/Record/' + data.data[i]['id'] + '">' + title + '</a>';
+                        var href = '<a href="/vufind/'+RecordPath+'/' + data.data[i]['id'] + '">' + title + '</a>';
                         var item = data.data[i]['prefix'] + href;
                         jQuery('ul#DependentWorks').append('<li>' + item + '</li>');
                     }
@@ -36,14 +43,14 @@ jQuery(document).ready(function() {
                         jQuery('p#ToggleDependentWorksMore').attr('style', 'display:block');
                         for (var i = visibleItems; i < data.data.length; i++) {
                             var title = data.data[i]['title'];
-                            var href = '<a href="/vufind/Record/' + data.data[i]['id'] + '">' + title + '</a>';
+                            var href = '<a href="/vufind/'+RecordPath+'/' + data.data[i]['id'] + '">' + title + '</a>';
                             var item = data.data[i]['prefix'] + href;
                             jQuery('ul#DependentWorksHidden').append('<li>' + item + '</li>');
                         }
                     }
                 }
                 jQuery('div#DependentWorks').attr('style', 'display:block');
-				jQuery('div#DependentWorksRotator').attr('style', 'display:none');
+                jQuery('div#DependentWorksRotator').attr('style', 'display:none');
             } else {
                 jQuery('div#DependentWorks').attr('style', 'display:none');
             }

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -43,8 +43,11 @@ jQuery(document).ready(function() {
                     }
                 }
                 jQuery('div#DependentWorks').attr('style', 'display:block');
+				jQuery('div#DependentWorksRotator').attr('style', 'display:none');
+            } else {
+                jQuery('div#DependentWorks').attr('style', 'display:none');
             }
-        }
+        } 
     });
 
     jQuery('#ToggleDependentWorksMore').on('click', function(event) {

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function() {
     var SearchClassId = 'Solr';
     var ResultPath = 'Search';
     var RecordPath = 'Record';
-    var pathParts = window.location.href.split('/');
+    var pathParts = window.location.pathname.split('/');
     var recordIndex = pathParts.length - 1;
     if (pathParts[recordIndex] == 'Record' || pathParts[recordIndex] == 'Search2Record') {
       recordId = pathParts[(recordIndex + 1)];

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -1,6 +1,7 @@
 jQuery(document).ready(function() {
     var recordId;
     var SearchClassId = 'Solr';
+    var ResultPath = 'Search';
     var RecordPath = 'Record';
     var pathParts = window.location.href.split('/');
     var recordIndex = pathParts.length - 1;
@@ -17,6 +18,7 @@ jQuery(document).ready(function() {
     
     if (pathParts[recordIndex] == 'Search2Record') {
       var SearchClassId = 'Search2';
+      var ResultPath = 'Search2';
       var RecordPath = 'Search2Record';
     }
 
@@ -27,7 +29,7 @@ jQuery(document).ready(function() {
         success:function(data, textStatus) {
             if (data.data.length > 0) {
                 if (data.data[0]['resultString'] !== undefined) {
-                    var href = '<a href="/vufind/'+SearchClassId+'/Results?lookfor='+data.data[0]['searchfield']+':'
+                    var href = '<a href="/vufind/'+ResultPath+'/Results?lookfor='+data.data[0]['searchfield']+':'
                             + recordId + ' -id:'  + recordId + '&filter[]='+data.data[0]['filter']+'&sort=year">'
                             + data.data[0]['resultString'] + '</a>'
                     jQuery('ul#DependentWorks').append('<li>' + href + '</li>');

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -2,11 +2,11 @@ jQuery(document).ready(function() {
     var recordId;
     var pathParts = window.location.href.split('/');
     var recordIndex = pathParts.length - 1;
-    if (pathParts[recordIndex] == 'Record') {
+    if (pathParts[recordIndex] == 'Record' || pathParts[recordIndex] == 'Search2Record') {
       recordId = pathParts[(recordIndex + 1)];
     } else {
       recordIndex--;
-      if (pathParts[recordIndex] == 'Record') {
+      if (pathParts[recordIndex] == 'Record' || pathParts[recordIndex] == 'Search2Record') {
         recordId = pathParts[(recordIndex + 1)];
       } else {
         recordId = 0;

--- a/themes/dependentworks/js/dependentworks.js
+++ b/themes/dependentworks/js/dependentworks.js
@@ -21,7 +21,7 @@ jQuery(document).ready(function() {
             if (data.data.length > 0) {
                 if (data.data[0]['resultString'] !== undefined) {
                     var href = '<a href="/vufind/Search/Results?lookfor='+data.data[0]['searchfield']+':'
-                            + recordId + ' -id:'  + recordId + '&sort=year">'
+                            + recordId + ' -id:'  + recordId + '&filter[]='+data.data[0]['filter']+'&sort=year">'
                             + data.data[0]['resultString'] + '</a>'
                     jQuery('ul#DependentWorks').append('<li>' + href + '</li>');
                 } else {


### PR DESCRIPTION
**Neue Konfigurationsmöglichkeiten**
- searchfield: Standardmäßig wird im Index-Feld hierarchy_top_id nach der PPN des Records gesucht. Das Suchfeld sollte konfigurierbar sein. Zum Beispiel wird in den "Altsystemen" das Feld ppnlink genutzt. Dies liefert für uns, Braunschweig, auch die besseren Ergebnisse. Bei hierarchy_top_id fehlen anscheinend einige Records, oder es werden bei der Belegung des Feldes nicht alle die berücksichtigt, die bei ppnlink berücksichtigt werden. In der config/vufind/dependent-works.ini ist es nun möglich den Parameter searchfield mit einem Solr-Feld als Wert einzutragen. Damit dies Wirkung erzielt, wurden Änderungen in module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php  vorgenommen, erst eine Prüfung, ob der Konfigurationsparameter vorhanden und belegt ist und dann Anpassungen der initFromRequest- und formatResponse-Aufrufe. Auch wurde eine Anpassung in themes/dependentworks/js/dependentworks.js vorgenommen und hierarchy_top_id durch data.data[0]['searchfield'] ersetzt (nun Zeile 32). Die Änderungen haben nur Auswirkungen, wenn die Konfigurationsparameter gesetzt sind. Das Verhalten bleibt ansonsten gleich.
- filter: In Braunschweig haben wir den Fall, dass wir im ersten Reiter nicht nur unsere eigenen Bestände ohne Artikel durchsuchbar machen. Dies führte dazu, dass z.B. beim Spiegel über 70.000 Artikel als DependentWorks erkannt wurden. Im ersten Moment ist das sinnvoll. Allerdings führen die Artikel wieder zurück zur Zeitschrift, was dazu führen könnte, dass der Nutzer "im Kreis läuft". Deshalb hatten wir uns im "Altsystem" dafür entschieden, dass Artikel nicht in der Liste angezeigt werden sollen. Dies kann für uns nun mit 
filter = '-format:Article'
abgebildet werden.
Mit diesem konfigurierbaren Filter kann dies für verschiedene Szenarien von DependentWorks genutzt werden. Dies wurde durch Damit dies Wirkung erzielt, wurden Änderungen in module/DependentWorks/src/DependentWorks/AjaxHandler/GetDependentWorks.php  vorgenommen, erst eine Prüfung, ob der Konfigurationsparameter vorhanden und belegt ist und dann Anpassungen der initFromRequest- und formatResponse-Aufrufe. Auch wurden Änderungen in themes/dependentworks/js/dependentworks.js vorgenommen (Ergänzung von &filter[]='+data.data[0]['filter'] in nun Zeile 33). Die Änderungen haben nur Auswirkungen, wenn die Konfigurationsparameter gesetzt sind. Das Verhalten bleibt ansonsten gleich.

**Bugfixes**

Bugfix 1: Anfragen nach DependentWorks wurden aus Search2Record auch an SearchClassId Solr (also Konfiguration des 1. Reiters) geschickt. Man erhielt also die DependentWorks aus dem 1. Reiter und wurde auch zu diesen oder einer Suche darin weitergeleitet. Dies ist mit Anpassungen an themes/dependentworks/js/dependentworks.js mit Variablen SearchClassId, ResultPath und RecordPath behoben.

Bugfix 2: HTML-Elemente #DependentWorks und #DependentWorksRotator wurden nicht ausgeblendet. Lagen keine DependentWorks vor, blieb der Kasten #DependentWorks weiterhin eingeblendet. Wurden DependentWorks gefunden, blieb die rotierende Graphik #DependentWorksRotator weiterhin sichtbar. Dies ist mit Anpassungen an themes/dependentworks/js/dependentworks.js in nun Zeilen 55 bis 57 behoben worden.