### PR TITLE
Erweiterung des Feeback-Controllers: Falls in der Konfiguration reply…

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1591,7 +1591,7 @@ treeSearchLimit = 100
 ;sender_name       = "VuFind Feedback"
 ; This can be set to "sender_email" (Reply-to not set = default)
 ; or "user_email" (Reply-to ist set to users email address)
-;reply-to          = sender_email
+;reply_to          = sender_email
 
 ; Note: for additional details about stats (including additional notes on Google
 ; Analytics and Piwik), look at the wiki page:

--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -1589,6 +1589,9 @@ treeSearchLimit = 100
 ; This is the information for where feedback emails are sent from.
 ;sender_email      = "noreply@vufind.org"
 ;sender_name       = "VuFind Feedback"
+; This can be set to "sender_email" (Reply-to not set = default)
+; or "user_email" (Reply-to ist set to users email address)
+;reply-to          = sender_email
 
 ; Note: for additional details about stats (including additional notes on Google
 ; Analytics and Piwik), look at the wiki page:

--- a/module/ExtendedFeedback/Module.php
+++ b/module/ExtendedFeedback/Module.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * ZF2 module definition for the VuFind application
+ *
+ * PHP version 7
+ *
+ * Copyright (C) Villanova University 2010.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Module
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+namespace ExtendedFeedback;
+
+use Zend\Mvc\MvcEvent;
+
+/**
+ * ZF2 module definition for the VuFind application
+ *
+ * @category VuFind
+ * @package  Module
+ * @author   Demian Katz <demian.katz@villanova.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org
+ */
+class Module
+{
+    /**
+     * Get module configuration
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+        return include __DIR__ . '/config/module.config.php';
+    }
+
+    /**
+     * Get autoloader configuration
+     *
+     * @return array
+     */
+    public function getAutoloaderConfig()
+    {
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
+                    __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
+                ],
+            ],
+        ];
+    }
+}

--- a/module/ExtendedFeedback/config/module.config.php
+++ b/module/ExtendedFeedback/config/module.config.php
@@ -1,0 +1,17 @@
+<?php
+namespace ExtendedFeedback\Module\Configuration;
+
+$config = [
+    'controllers' => [
+        'factories' => [
+            'ExtendedFeedback\Controller\FeedbackController' => 'VuFind\Controller\AbstractBaseFactory',
+        ],
+        'aliases' => [
+            'Feedback' => 'ExtendedFeedback\Controller\FeedbackController',
+            'feedback' => 'ExtendedFeedback\Controller\FeedbackController',
+            'VuFind\Controller\FeedbackController' => 'ExtendedFeedback\Controller\FeedbackController',
+        ],
+    ],
+];
+
+return $config;

--- a/module/ExtendedFeedback/src/ExtendedFeedback/Controller/FeedbackController.php
+++ b/module/ExtendedFeedback/src/ExtendedFeedback/Controller/FeedbackController.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Feedback Controller
+ *
+ * PHP version 7
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Josiah Knoll <jk1135@ship.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace ExtendedFeedback\Controller;
+
+use VuFind\Exception\Mail as MailException;
+use Zend\Mail\Address;
+use VuFind\Controller\FeedbackController as BasicFeedbackController;
+
+/**
+ * Feedback Class
+ *
+ * Controls the Feedback
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Josiah Knoll <jk1135@ship.edu>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class FeedbackController extends BasicFeedbackController
+{
+    /**
+     * Receives input from the user and sends an email to the recipient set in
+     * the config.ini
+     *
+     * @return void
+     */
+    public function emailAction()
+    {
+        $view = $this->createViewModel();
+        $view->useRecaptcha = $this->recaptcha()->active('feedback');
+        $view->name = $this->params()->fromPost('name');
+        $view->email = $this->params()->fromPost('email');
+        $view->comments = $this->params()->fromPost('comments');
+
+        // Process form submission:
+        if ($this->formWasSubmitted('submit', $view->useRecaptcha)) {
+            if (empty($view->email) || empty($view->comments)) {
+                $this->flashMessenger()->addMessage('bulk_error_missing', 'error');
+                return;
+            }
+
+            // These settings are set in the feedback settion of your config.ini
+            $config = $this->serviceLocator->get('VuFind\Config\PluginManager')
+                ->get('config');
+            $feedback = isset($config->Feedback) ? $config->Feedback : null;
+            $recipient_email = isset($feedback->recipient_email)
+                ? $feedback->recipient_email : null;
+            $recipient_name = isset($feedback->recipient_name)
+                ? $feedback->recipient_name : 'Your Library';
+            $email_subject = isset($feedback->email_subject)
+                ? $feedback->email_subject : 'VuFind Feedback';
+            $sender_email = isset($feedback->sender_email)
+                ? $feedback->sender_email : 'noreply@vufind.org';
+            $sender_name = isset($feedback->sender_name)
+                ? $feedback->sender_name : 'VuFind Feedback';
+            $reply_to = (isset($feedback->reply-to) && $feedback->reply-to == 'user_email')
+                ? $view->email : null;
+            if ($recipient_email == null) {
+                throw new \Exception(
+                    'Feedback Module Error: Recipient Email Unset (see config.ini)'
+                );
+            }
+
+            $email_message = empty($view->name) ? '' : 'Name: ' . $view->name . "\n";
+            $email_message .= 'Email: ' . $view->email . "\n";
+            $email_message .= 'Comments: ' . $view->comments . "\n\n";
+
+            // This sets up the email to be sent
+            // Attempt to send the email and show an appropriate flash message:
+            try {
+                $mailer = $this->serviceLocator->get('VuFind\Mailer\Mailer');
+                $mailer->send(
+                    new Address($recipient_email, $recipient_name),
+                    new Address($sender_email, $sender_name),
+                    $email_subject, $email_message,
+                    null,
+                    $reply_to
+                );
+                $this->flashMessenger()->addMessage(
+                    'Thank you for your feedback.', 'success'
+                );
+            } catch (MailException $e) {
+                $this->flashMessenger()->addMessage($e->getMessage(), 'error');
+            }
+        }
+        return $view;
+    }
+}

--- a/module/ExtendedFeedback/src/ExtendedFeedback/Controller/FeedbackController.php
+++ b/module/ExtendedFeedback/src/ExtendedFeedback/Controller/FeedbackController.php
@@ -64,7 +64,7 @@ class FeedbackController extends BasicFeedbackController
                 ? $feedback->sender_email : 'noreply@vufind.org';
             $sender_name = isset($feedback->sender_name)
                 ? $feedback->sender_name : 'VuFind Feedback';
-            $reply_to = (isset($feedback->reply-to) && $feedback->reply-to == 'user_email')
+            $reply_to = (isset($feedback->reply_to) && $feedback->reply_to == 'user_email')
                 ? $view->email : null;
             if ($recipient_email == null) {
                 throw new \Exception(


### PR DESCRIPTION
…-to = user_email gesetzt ist, wird der Reply-to-Header der Email auf die Emailadresse des Nutzers gesetzt (die in dem Formular eine Plichtangabe ist). Ansonsten wird kein Reply-to-Header gesetzt - wie gehabt.