### PR TITLE
Cookie mit alten Backends

### DIFF
--- a/module/VuFind/src/VuFind/Cookie/CookieManager.php
+++ b/module/VuFind/src/VuFind/Cookie/CookieManager.php
@@ -93,6 +93,8 @@ class CookieManager
      */
     public function getCookies()
     {
+        $this->cookies = str_ireplace('VuFind','Solr', $this->cookies);
+        $this->cookies = str_ireplace('SolrFindex','Search2', $this->cookies);
         return $this->cookies;
     }
 


### PR DESCRIPTION
Führt zu Fehlermeldung in Favoritenliste bei Aufruf in wenigen Fällen