### PR TITLE
Ergänzung des DAIAplus-Moduls: Konfiguration weiterer Backends für die Verfügbarkeitsanzeige

### DIFF
--- a/module/DAIAplus/src/DAIAplus/AjaxHandler/GetItemStatuses.php
+++ b/module/DAIAplus/src/DAIAplus/AjaxHandler/GetItemStatuses.php
@@ -223,6 +223,9 @@ class GetItemStatuses extends \VuFind\AjaxHandler\GetItemStatuses
                 );
 //neu A
                 $current['record_number'] = array_search($current['id'], $ids);
+
+                $current['daiaBackend'] = $recordNumber;
+
                 $statuses[] = $current;
 
                 // The current ID is not missing -- remove it from the missing list.
@@ -242,7 +245,8 @@ class GetItemStatuses extends \VuFind\AjaxHandler\GetItemStatuses
                 'reserve_message'      => $this->translate('Not On Reserve'),
                 'callnumber'           => '',
                 'missing_data'         => true,
-                'record_number'        => $recordNumber
+                'record_number'        => $recordNumber,
+                'daiaBackend'          => ''
             ];
         }
 

--- a/module/DAIAplus/src/DAIAplus/ILS/Driver/DAIA.php
+++ b/module/DAIAplus/src/DAIAplus/ILS/Driver/DAIA.php
@@ -170,7 +170,7 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
             $this->baseUrl = $daiaBackend['baseUrl'];
             $this->apiKey = $daiaBackend['daiaplus_api_key'];
             $isCurrentIsil = true;
-            if (isset($daiaBackend['isil'])) {
+            if (isset($daiaBackend['isil']) && $paiaIsil != '') {
                 if ($paiaIsil != $daiaBackend['isil']) {
                     $isCurrentIsil = false;
                 }
@@ -443,14 +443,6 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
     protected function getPAIADomain()
     {
         $session = $this->getSession();
-        if (empty($session->paia_domain)) {
-            // Get PAIA domain from login form.
-            $paiaDomain = 'PAIA';
-            if (isset($_POST['paia-select'])) {
-                $paiaDomain = $_POST['paia-select'];
-            }
-            $session->paia_domain  = $paiaDomain;
-        }
         return $session->paia_domain;
     }
 }

--- a/module/DAIAplus/src/DAIAplus/ILS/Driver/DAIA.php
+++ b/module/DAIAplus/src/DAIAplus/ILS/Driver/DAIA.php
@@ -132,6 +132,116 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
     }
 
     /**
+     * Get Statuses
+     *
+     * This is responsible for retrieving the status information for a
+     * collection of records.
+     * As the DAIA Query API supports querying multiple ids simultaneously
+     * (all ids divided by "|") getStatuses(ids) would call getStatus(id) only
+     * once, id containing the list of ids to be retrieved. This would cause some
+     * trouble as the list of ids does not necessarily correspond to the VuFind
+     * Record-id. Therefore getStatuses(ids) has its own logic for multiQuery-support
+     * and performs the HTTPRequest itself, retrieving one DAIA response for all ids
+     * and uses helper functions to split this one response into documents
+     * corresponding to the queried ids.
+     *
+     * @param array $ids The array of record ids to retrieve the status for
+     *
+     * @return array    An array of status information values on success.
+     */
+    public function getStatuses($ids)
+    {
+        $daiaBackends = [];
+        foreach ($this->config as $key => $value) {
+            if (stristr($key, 'DAIA')) {
+                $daiaBackends[$key] = $value;
+            }
+        }
+
+        $paiaDomain = $this->getPAIADomain();
+        $paiaIsil = '';
+        if (isset($this->config[$paiaDomain]['isil'])) {
+            $paiaIsil = $this->config[$paiaDomain]['isil'];
+        }
+
+        $status = [];
+        foreach ($daiaBackends as $daiaBackend) {
+
+            $this->baseUrl = $daiaBackend['baseUrl'];
+            $this->apiKey = $daiaBackend['daiaplus_api_key'];
+            $isCurrentIsil = true;
+            if (isset($daiaBackend['isil'])) {
+                if ($paiaIsil != $daiaBackend['isil']) {
+                    $isCurrentIsil = false;
+                }
+            }
+
+            // check cache for given ids and skip these ids if availability data is found
+            foreach ($ids as $key => $id) {
+                if ($this->daiaCacheEnabled
+                    && $item = $this->getCachedData($this->generateURI($id))
+                ) {
+                    if ($item != null) {
+                        $status[] = $item;
+                        unset($ids[$key]);
+                    }
+                }
+            }
+
+            // only query DAIA service if we have some ids left
+            if (count($ids) > 0) {
+                try {
+                    if ($this->multiQuery) {
+                        // perform one DAIA query with multiple URIs
+                        $rawResult = $this
+                            ->doHTTPRequest($this->generateMultiURIs($ids));
+                        // the id used in VuFind can differ from the document-URI
+                        // (depending on how the URI is generated)
+                        foreach ($ids as $id) {
+                            // it is assumed that each DAIA document has a unique URI,
+                            // so get the document with the corresponding id
+                            $doc = $this->extractDaiaDoc($id, $rawResult);
+                            if (null !== $doc) {
+                                // a document with the corresponding id exists, which
+                                // means we got status information for that record
+                                $data = $this->parseDaiaDoc($id, $doc, $isCurrentIsil);
+                                // cache the status information
+                                if ($this->daiaCacheEnabled) {
+                                    $this->putCachedData($this->generateURI($id), $data);
+                                }
+                                $status[$daiaBackend['name']] = $data;
+                            }
+                            unset($doc);
+                        }
+                    } else {
+                        // multiQuery is not supported, so retrieve DAIA documents one by
+                        // one
+                        foreach ($ids as $id) {
+                            $rawResult = $this->doHTTPRequest($this->generateURI($id));
+                            // extract the DAIA document for the current id from the
+                            // HTTPRequest's result
+                            $doc = $this->extractDaiaDoc($id, $rawResult);
+                            if (null !== $doc) {
+                                // parse the extracted DAIA document and save the status
+                                // info
+                                $data = $this->parseDaiaDoc($id, $doc, $isCurrentIsil);
+                                // cache the status information
+                                if ($this->daiaCacheEnabled) {
+                                    $this->putCachedData($this->generateURI($id), $data);
+                                }
+                                $status[$daiaBackend['name']] = $data;
+                            }
+                        }
+                    }
+                } catch (ILSException $e) {
+                    $this->debug($e->getMessage());
+                }
+            }
+        }
+        return $status;
+    }
+
+    /**
      * Perform an HTTP request.
      *
      * @param string $id id for query in daia
@@ -214,7 +324,7 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
      *
      * @return array            Array with VuFind compatible status information.
      */
-    protected function parseDaiaArray($id, $daiaArray)
+    protected function parseDaiaArray($id, $daiaArray, $isCurrentIsil)
     {
         $doc_id = null;
         $doc_href = null;
@@ -275,6 +385,8 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
                     $result_item['chronology'] = $item['chronology'];
                 }
 
+                $result_item['isCurrentIsil'] = $isCurrentIsil;
+
                 $result[] = $result_item;
             } // end iteration on item
         }
@@ -301,10 +413,10 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
      * @return array An array with status information for the record
      * @throws ILSException
      */
-    protected function parseDaiaDoc($id, $daiaDoc)
+    protected function parseDaiaDoc($id, $daiaDoc, $isCurrentIsil)
     {
         if (is_array($daiaDoc)) {
-            return $this->parseDaiaArray($id, $daiaDoc);
+            return $this->parseDaiaArray($id, $daiaDoc, $isCurrentIsil);
         } else {
             throw new ILSException(
                 'Unsupported document type (did not match Array or DOMNode).'
@@ -328,4 +440,17 @@ class DAIA extends \VuFind\ILS\Driver\PAIA
         return $session->daia_domain;
     }
 
+    protected function getPAIADomain()
+    {
+        $session = $this->getSession();
+        if (empty($session->paia_domain)) {
+            // Get PAIA domain from login form.
+            $paiaDomain = 'PAIA';
+            if (isset($_POST['paia-select'])) {
+                $paiaDomain = $_POST['paia-select'];
+            }
+            $session->paia_domain  = $paiaDomain;
+        }
+        return $session->paia_domain;
+    }
 }

--- a/module/PAIAplus/src/PAIAplus/Controller/MyResearchController.php
+++ b/module/PAIAplus/src/PAIAplus/Controller/MyResearchController.php
@@ -166,7 +166,14 @@ class MyResearchController extends \VuFind\Controller\MyResearchController
                 if (isset($paiaConfig[$key]['name'])) {
                     $name = $paiaConfig[$key]['name'];
                 }
-                $paiaBackends[$key] = $name;
+                $docIdPattern = '';
+                if (isset($paiaConfig[$key]['docIdPattern'])) {
+                    $docIdPattern = $paiaConfig[$key]['docIdPattern'];
+                }
+                $paiaBackends[$key] = [
+                    'name' => $name,
+                    'docIdPattern' => $docIdPattern
+                ];
             }
         }
         $view->paiaBackends = $paiaBackends;

--- a/themes/daiaplus/css/daiaplus.css
+++ b/themes/daiaplus/css/daiaplus.css
@@ -111,3 +111,9 @@
   content: url("../images/questionmark_orange.png");
   margin-left: 5px;
 }
+
+.daia_backend_not_matching {
+    font-weight: bold;
+    display: block;
+    font-style: italic;
+}

--- a/themes/daiaplus/js/check_item_statuses.js
+++ b/themes/daiaplus/js/check_item_statuses.js
@@ -31,8 +31,13 @@ function displayArticleStatus(results, $item) {
 }
 
 function displayItemStatus(result, $item) {
+  if (typeof(result.daiaBackend) != 'undefined') {
+      $item.find('.status').append('<h3>'+result.daiaBackend+'</h3>');
+  }
+
   $item.removeClass('js-item-pending');
-  $item.find('.status').empty().append(result.availability_message);
+  $item.find('.status').find('.label').remove();
+  $item.find('.status').append(result.availability_message);
   $item.find('.ajax-availability').removeClass('ajax-availability hidden');
   if (typeof(result.error) != 'undefined'
     && result.error.length > 0
@@ -95,7 +100,8 @@ function displayItemStatus(result, $item) {
   }
   if (typeof(result.daiaplus) != 'undefined' && result.daiaplus.length > 0) {
     $item.find('.callnumAndLocation').addClass('hidden');
-    $item.find('.status').empty().append(result.daiaplus);
+    $item.find('.status').find('.label').remove();
+    $item.find('.status').append(result.daiaplus);
     $item.find('.status').removeClass('hidden');
   }
 }

--- a/themes/daiaplus/templates/ajax/daiaplus.phtml
+++ b/themes/daiaplus/templates/ajax/daiaplus.phtml
@@ -130,17 +130,21 @@ foreach ($cumulatedResults as $storage => $cumulatedResult) {
                         }
 
                         if (!$hideLink) {
-                            if ($status != '' && (in_array($actionEntry['service'], array("loan", "presentation")))) {
-                                echo ' &#10141;';
-                            }
+                            if ($daiaResult['isCurrentIsil']) {
+                                if ($status != '' && (in_array($actionEntry['service'], array("loan", "presentation")))) {
+                                    echo ' &#10141;';
+                                }
 
-                            echo ' <span class="daia_action">';
-                            if ($action_href) {
-                                echo '<a class="' . $actionEntry['link_status'] . '" href="' . $action_href . '" target="_blank">' . $action_label . '</a>';
+                                echo ' <span class="daia_action">';
+                                if ($action_href) {
+                                    echo '<a class="' . $actionEntry['link_status'] . '" href="' . $action_href . '" target="_blank">' . $action_label . '</a>';
+                                } else {
+                                    echo $action_label;
+                                }
+                                echo '</span>';
                             } else {
-                                echo $action_label;
+                                echo '<span class="daia_backend_not_matching">'.$this->transEsc('Please login with a matching account').'</span>';
                             }
-                            echo '</span>';
                         }
                     }
                 }

--- a/themes/paiaplus/templates/Auth/AbstractBase/paia-select.phtml
+++ b/themes/paiaplus/templates/Auth/AbstractBase/paia-select.phtml
@@ -3,7 +3,17 @@
     <label class="control-label" for="login_paia_select"><?=$this->transEsc('PAIA Select')?>:</label>
     <select name="paia-select" id="login_paia_select">
         <?php foreach ($this->paiaBackends as $key => $value): ?>
-            <option value="<?=$key?>" <?php if ($this->request->get('paia-select') == $key): ?>selected="selected"<?php endif; ?>><?=$value?></option>
+            <?php
+                $selected = false;
+                if ($this->request->get('paia-select') == $key) {
+                    $selected = true;
+                } else if (isset($_GET['doc_id'])) {
+                    if (stristr($_GET['doc_id'], $value['docIdPattern'])) {
+                        $selected = true;
+                    }
+                }
+            ?>
+            <option value="<?=$key?>" <?php if($selected): ?>selected="selected"<?php endif; ?>><?=$value['name']?></option>
         <?php endforeach; ?>
     </select>
 </div>


### PR DESCRIPTION
Erweiterung von DAIAplus, die (analog zu PAIAplus) die Konfiguration mehrerer Backend erlaubt. Bei den Verfügbarkeiten werden kann die Exemplare dieser Standorte angezeigt:

<img width="308" alt="Bildschirmfoto 2020-12-14 um 10 28 29" src="https://user-images.githubusercontent.com/4047699/102064078-290f0a00-3df7-11eb-8152-a8bce0472ce6.png">

Nach dem Anmelden werden die Links zum Bestellen und Vormerken mit dem aktuellen Login abgeglichen, so dass nur Exemplare aus dem passenden Backend bestellt werden können. Bei Exemplaren anderer Backend erscheint ein entsprechender Hinweis:

<img width="312" alt="Bildschirmfoto 2020-12-14 um 10 31 53" src="https://user-images.githubusercontent.com/4047699/102064472-a0449e00-3df7-11eb-8b72-07cc79c71af5.png">

Bei Nutzung eines `bestellen`- oder `vormerken`-Links vor der Anmeldung wird über ein Matching der doc_id versucht, das richtige Backend im Dropdown des Anmeldeformular vorauszuwählen:

<img width="296" alt="Bildschirmfoto 2020-12-14 um 10 34 03" src="https://user-images.githubusercontent.com/4047699/102064731-f7e30980-3df7-11eb-9c91-5c56e0250cbf.png">

Die Konfiguration muss nur bei der Nutzung mehrere Backends angepasst werden.

PAIA.ini vorher:
```
[DAIA]
baseUrl            = https://daiaplus.beluga-core.de/index.php/api/daiaplus/availability/
daiaplus_api_key   = ...
daiaIdPrefix       = ""
daiaResponseFormat = json
```

PAIA.ini nachher:
```
[DAIA]
baseUrl            = https://daiaplus.beluga-core.de/index.php/api/daiaplus/availability/
daiaplus_api_key   = ...
daiaIdPrefix       = ""
daiaResponseFormat = json
isil               = "DE-960"
name               = "HsH"

[DAIA_DE-960-3]
baseUrl            = https://daiaplus.beluga-core.de/index.php/api/daiaplus/availability/
daiaplus_api_key   = ...
daiaIdPrefix       = ""
daiaResponseFormat = json
isil               = "DE-960-3"
name               = "KSF"
```

Wie schon beim Ausbau von PAIAplus für mehrere Backends bleibt `[DAIA]` die Konfiguration für den Standard-Fall. Weitere Blöcke `[DAIA_<ISIL>]` sind für weitere Backends vorgesehen.

Die Konfiguration in den `[PAIA]`-Blöcken kann folgendermaßen ergänzt werden:

PAIA.ini vorher:
```
[PAIA]
baseUrl           = "https://vhlbs.tib.eu:13249/DE-960/"
name              = "Hochschule Hannover"
```

PAIA.in nachher:
```
[PAIA]
baseUrl           = "https://vhlbs.tib.eu:13249/DE-960/"
isil              = "DE-960"
name              = "Hochschule Hannover"
docIdPattern      = "http://uri.gbv.de/document/opac-de-960:ppn:"
```

Die Angabe `isil` wird für den Abgleich mit einem passenden `[DAIA]`-Block ergänzt. Die Angabe `docIdPattern` wird für die Vorauswahl des Backends im Login bei der Nutzung eines `bestellen`- oder `vormerken`-Links verwendet.