### PR TITLE
Avoid short_open_tags

### DIFF
--- a/themes/availabilityplus/templates/record/availabilityplus-view.phtml
+++ b/themes/availabilityplus/templates/record/availabilityplus-view.phtml
@@ -5,6 +5,6 @@
     <?php if(!empty($_GET['debug_ap']) && strip_tags($_GET['debug_ap']) == 'true') { ?>
         <div class="delimiter"></div>
         <a href="/vufind/AvailabilityPlus/Debug/<?=$this->driver->getUniqueID();?>?driver=<?=$this->driver->getSourceIdentifier();?>&list=0" target="_blank"><?=$this->transEsc('DebugView')?></a>
-    <? } ?>
+    <?php } ?>
 </div>
 


### PR DESCRIPTION
PHP setting `short_open_tags` is deprecated in newer versions and `off` by default even in older version. So we should not rely on this setting being `on`.